### PR TITLE
Add ground stations

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,3 +117,24 @@ def get_satellite_paths():
             continue
 
     return satellites
+
+
+@app.get("/ground_stations")
+def get_ground_stations():
+    conn = psycopg2.connect(
+        dbname=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+        host=os.getenv("POSTGRES_HOST"),
+        port=5432,
+    )
+    cur = conn.cursor()
+    cur.execute("SELECT name, lat, lon FROM ground_stations;")
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return [
+        {"name": name, "lat": lat, "lon": lon}
+        for name, lat, lon in rows
+    ]
+

--- a/database/init/01-init.sql
+++ b/database/init/01-init.sql
@@ -11,3 +11,11 @@ CREATE TABLE IF NOT EXISTS satellite_tles (
 );
 
 SELECT create_hypertable('satellite_tles', 'epoch', if_not_exists => TRUE);
+
+-- Ground station locations
+CREATE TABLE IF NOT EXISTS ground_stations (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE,
+  lat DOUBLE PRECISION,
+  lon DOUBLE PRECISION
+);

--- a/frontend/src/components/CesiumMap.tsx
+++ b/frontend/src/components/CesiumMap.tsx
@@ -7,6 +7,7 @@ export default function CesiumMap() {
   const viewerRef = useRef<HTMLDivElement | null>(null);
   const viewer = useRef<Cesium.Viewer | null>(null);
   const satelliteEntities = useRef<{ [id: string]: Cesium.Entity }>({});
+  const groundEntities = useRef<Cesium.Entity[]>([]);
 
   const getApiBase = () => {
     const { hostname } = window.location;
@@ -99,6 +100,31 @@ export default function CesiumMap() {
       .catch((err) => console.error("TLE fetch error", err));
   };
 
+  const loadGroundStations = () => {
+    fetch(`${getApiBase()}/ground_stations`)
+      .then((res) => res.json())
+      .then((data) => {
+        data.forEach((gs: any) => {
+          const pos = Cesium.Cartesian3.fromDegrees(gs.lon, gs.lat, 0);
+          const entity = viewer.current?.entities.add({
+            position: pos,
+            point: { pixelSize: 8, color: Cesium.Color.CYAN },
+            label: {
+              text: gs.name,
+              font: "12px sans-serif",
+              fillColor: Cesium.Color.CYAN,
+              style: Cesium.LabelStyle.FILL_AND_OUTLINE,
+              outlineWidth: 2,
+              verticalOrigin: Cesium.VerticalOrigin.TOP,
+              pixelOffset: new Cesium.Cartesian2(0, -20),
+            },
+          });
+          if (entity) groundEntities.current.push(entity);
+        });
+      })
+      .catch((err) => console.error("Ground station fetch error", err));
+  };
+
 
   useEffect(() => {
     if (!viewerRef.current) return;
@@ -136,8 +162,9 @@ export default function CesiumMap() {
       viewer.current.timeline.zoomTo(start, stop);
     }
 
-    // 🛰 Load satellites
+    // 🛰 Load satellites and ground stations
     updateSatellites();
+    loadGroundStations();
 
     // 🔁 Periodic update
     const interval = setInterval(updateSatellites, 60000);
@@ -151,3 +178,4 @@ export default function CesiumMap() {
 
   return <div ref={viewerRef} style={{ width: "100%", height: "100vh" }} />;
 }
+

--- a/generator/app/ground_stations.py
+++ b/generator/app/ground_stations.py
@@ -1,0 +1,39 @@
+import psycopg2
+import os
+
+GROUND_STATIONS = [
+    ("New York", 40.7128, -74.0060),
+    ("Los Angeles", 34.0522, -118.2437),
+    ("London", 51.5074, -0.1278),
+    ("Tokyo", 35.6895, 139.6917),
+    ("Sydney", -33.8688, 151.2093),
+    ("Paris", 48.8566, 2.3522),
+    ("Moscow", 55.7558, 37.6173),
+    ("Dubai", 25.2048, 55.2708),
+    ("Sao Paulo", -23.5505, -46.6333),
+    ("Johannesburg", -26.2041, 28.0473),
+]
+
+
+def populate_ground_stations():
+    conn = psycopg2.connect(
+        host=os.getenv("POSTGRES_HOST", "database"),
+        dbname=os.getenv("POSTGRES_DB", "netvis"),
+        user=os.getenv("POSTGRES_USER", "netvis"),
+        password=os.getenv("POSTGRES_PASSWORD", "netvis"),
+        port=os.getenv("POSTGRES_PORT", "5432"),
+    )
+    cur = conn.cursor()
+    for name, lat, lon in GROUND_STATIONS:
+        cur.execute(
+            """
+            INSERT INTO ground_stations (name, lat, lon)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (name) DO NOTHING;
+            """,
+            (name, lat, lon),
+        )
+    conn.commit()
+    cur.close()
+    conn.close()
+

--- a/generator/app/main.py
+++ b/generator/app/main.py
@@ -1,11 +1,15 @@
 try:
     from .fetch import fetch_and_store_tles
+    from .ground_stations import populate_ground_stations
 except ImportError:
     # Fallback when executed as a script without a package context
     from fetch import fetch_and_store_tles
+    from ground_stations import populate_ground_stations
 import time
 
 if __name__ == "__main__":
+    # Insert predetermined ground stations once
+    populate_ground_stations()
     while True:
         fetch_and_store_tles()
         time.sleep(3600)  # update every hour


### PR DESCRIPTION
## Summary
- support a new `ground_stations` table
- populate ground stations from generator
- serve ground station coordinates from backend
- display ground stations in Cesium frontend

## Testing
- `python3 -m py_compile generator/app/*.py backend/app/*.py`
- `npm install` *(fails: Cannot find module during install)*

------
https://chatgpt.com/codex/tasks/task_e_684c8364673c832b8822c8723e87590e