### PR TITLE
Fix Cesium clock sync

### DIFF
--- a/frontend/src/components/CesiumMap.tsx
+++ b/frontend/src/components/CesiumMap.tsx
@@ -44,7 +44,14 @@ export default function CesiumMap() {
               viewer.current.timeline.zoomTo(startTime, stopTime);
             }
           } else {
+            // Keep the Cesium clock in sync with the latest satellite path
+            viewer.current.clock.startTime = startTime.clone();
             viewer.current.clock.stopTime = stopTime.clone();
+            viewer.current.clock.currentTime = startTime.clone();
+
+            if (viewer.current.timeline) {
+              viewer.current.timeline.zoomTo(startTime, stopTime);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- resync Cesium clock with each satellite fetch to avoid disappearing satellites

## Testing
- `pytest`
- `npm install` *(fails: cannot stat cesium package)*

------
https://chatgpt.com/codex/tasks/task_e_684cc6ffe9f0832bb372e5717f70e97f