### PR TITLE
Add daily looping for satellite orbits

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -88,6 +88,8 @@ def get_satellite_paths():
     conn.close()
 
     now = datetime.utcnow()
+    start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_day = start_of_day + timedelta(days=1)
     satellites = []
 
     for satellite_id, name, tle1, tle2 in results:
@@ -95,8 +97,9 @@ def get_satellite_paths():
             sat = Satrec.twoline2rv(tle1, tle2)
             path = []
 
-            for t in range(0, 301, 10):  # every 10 sec for 5 minutes
-                dt = now + timedelta(seconds=t)
+            total_seconds = int((end_of_day - start_of_day).total_seconds())
+            for t in range(0, total_seconds + 1, 60):  # every 1 min for 24 hours
+                dt = start_of_day + timedelta(seconds=t)
                 jd, fr = jday(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
                 err, pos, _ = sat.sgp4(jd, fr)
                 if err == 0:

--- a/frontend/src/components/CesiumMap.tsx
+++ b/frontend/src/components/CesiumMap.tsx
@@ -35,8 +35,9 @@ export default function CesiumMap() {
 
           if (firstLoad.current) {
             viewer.current.clock.startTime = startTime.clone();
+            viewer.current.clock.stopTime = stopTime.clone();
             viewer.current.clock.currentTime = startTime.clone();
-            viewer.current.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
+            viewer.current.clock.clockRange = Cesium.ClockRange.LOOP_STOP;
             viewer.current.clock.multiplier = 10;
 
             if (viewer.current.timeline) {
@@ -146,7 +147,8 @@ export default function CesiumMap() {
 
     // ⏱ Sync Cesium clock with satellite timestamps
     const startDate = new Date();
-    const stopDate = new Date(startDate.getTime() + 6 * 60 * 1000); // 6 minutes
+    startDate.setUTCHours(0, 0, 0, 0);
+    const stopDate = new Date(startDate.getTime() + 24 * 60 * 60 * 1000); // 24 hours
 
     const start = Cesium.JulianDate.fromDate(startDate);
     const stop = Cesium.JulianDate.fromDate(stopDate);


### PR DESCRIPTION
## Summary
- extend backend satellite path generation to 24 hours
- set clock to loop daily and initialise at midnight

## Testing
- `python -m py_compile backend/app/main.py`
- `npm run build` *(fails: Error [ERR_MODULE_NOT_FOUND])*

------
https://chatgpt.com/codex/tasks/task_e_684cd24052d4832bb3b37f1ca3257ff3